### PR TITLE
Progress > 100% #11

### DIFF
--- a/src/target.ts
+++ b/src/target.ts
@@ -54,7 +54,7 @@ export class Target {
 
   public async export() {
     this.exportedRows = 0;
-    this.days = (this.to - this.from) / MS_IN_DAY;
+    this.days = Math.round((this.to - this.from) / MS_IN_DAY);
     this.day = 0;
     this.initCsvStream();
 


### PR DESCRIPTION
closes https://github.com/CorpGlory/grafana-data-exporter/issues/11

Total number of days was a float number, now it is rounded up to an int => progress is no longer greater than 100%.